### PR TITLE
Add barber registration and dashboard

### DIFF
--- a/back-end/README.md
+++ b/back-end/README.md
@@ -12,6 +12,8 @@ The endpoints available are:
 
 - `POST /login` – Login with `phone` and `password`.
 - `POST /register` – Register a user with `name`, `phone` and `password`.
+- `POST /barber_login` – Login a barber with `phone` and `password`.
+- `POST /barber_register` – Register a barber with `name`, `phone` and `password`.
 - `GET /services?barber_id=1` – List available services for a barber.
 - `GET /availabilities?barber_id=1` – List available time slots for a barber.
 - `POST /appointments` – Create a new appointment.

--- a/back-end/public/barber_login.php
+++ b/back-end/public/barber_login.php
@@ -1,0 +1,23 @@
+<?php
+header('Content-Type: application/json');
+require 'config.php';
+
+$data = json_decode(file_get_contents('php://input'), true);
+
+if (!$data || empty($data['phone']) || empty($data['password'])) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Missing fields']);
+    exit;
+}
+
+$stmt = $pdo->prepare('SELECT barber_id, password_hash FROM barbers WHERE phone = ?');
+$stmt->execute([$data['phone']]);
+$barber = $stmt->fetch();
+
+if ($barber && password_verify($data['password'], $barber['password_hash'])) {
+    echo json_encode(['success' => true, 'barber_id' => $barber['barber_id']]);
+} else {
+    http_response_code(401);
+    echo json_encode(['error' => 'Invalid credentials']);
+}
+?>

--- a/back-end/public/barber_register.php
+++ b/back-end/public/barber_register.php
@@ -1,0 +1,23 @@
+<?php
+header('Content-Type: application/json');
+require 'config.php';
+
+$data = json_decode(file_get_contents('php://input'), true);
+
+if (!$data || empty($data['name']) || empty($data['phone']) || empty($data['password'])) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Missing fields']);
+    exit;
+}
+
+$hash = password_hash($data['password'], PASSWORD_BCRYPT);
+
+try {
+    $stmt = $pdo->prepare('INSERT INTO barbers (name, phone, password_hash) VALUES (?, ?, ?)');
+    $stmt->execute([$data['name'], $data['phone'], $hash]);
+    echo json_encode(['success' => true]);
+} catch (PDOException $e) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Barber registration failed']);
+}
+?>

--- a/back-end/public/index.php
+++ b/back-end/public/index.php
@@ -9,6 +9,12 @@ switch ($path) {
     case '/register':
         require 'register.php';
         break;
+    case '/barber_login':
+        require 'barber_login.php';
+        break;
+    case '/barber_register':
+        require 'barber_register.php';
+        break;
     case '/services':
         require 'services.php';
         break;

--- a/src/App.js
+++ b/src/App.js
@@ -2,6 +2,9 @@ import React from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import BarberPage from './pages/BarberPage';
 import LoginPage from './pages/LoginPage';
+import BarberAuthPage from './pages/BarberAuthPage';
+import BarberDashboard from './pages/BarberDashboard';
+import ProtectedRoute from './components/ProtectedRoute';
 
 function App() {
   return (
@@ -9,6 +12,15 @@ function App() {
       <Routes>
         <Route path="/" element={<BarberPage />} />
         <Route path="/login" element={<LoginPage />} />
+        <Route path="/barber/login" element={<BarberAuthPage />} />
+        <Route
+          path="/barber"
+          element={
+            <ProtectedRoute>
+              <BarberDashboard />
+            </ProtectedRoute>
+          }
+        />
       </Routes>
     </BrowserRouter>
   );

--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+
+function ProtectedRoute({ children }) {
+  const barberId = localStorage.getItem('barber_id');
+  return barberId ? children : <Navigate to="/barber/login" replace />;
+}
+
+export default ProtectedRoute;

--- a/src/pages/BarberAuthPage.jsx
+++ b/src/pages/BarberAuthPage.jsx
@@ -1,0 +1,74 @@
+import React, { useState } from 'react';
+
+const API = process.env.REACT_APP_API_BASE_URL;
+
+function BarberAuthPage() {
+  const [phone, setPhone] = useState('');
+  const [password, setPassword] = useState('');
+  const [name, setName] = useState('');
+  const [isRegister, setIsRegister] = useState(false);
+  const [message, setMessage] = useState('');
+
+  const handleSubmit = e => {
+    e.preventDefault();
+    const url = isRegister ? '/barber_register' : '/barber_login';
+    const payload = isRegister ? { name, phone, password } : { phone, password };
+
+    fetch(`${API}${url}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    })
+      .then(res => res.json())
+      .then(data => {
+        if (data.success) {
+          setMessage('Sucesso!');
+          if (data.barber_id) {
+            localStorage.setItem('barber_id', data.barber_id);
+          }
+        } else {
+          setMessage(data.error || 'Erro');
+        }
+      })
+      .catch(() => setMessage('Erro'));
+  };
+
+  return (
+    <div style={{ padding: '1rem', color: 'var(--primary-color)' }}>
+      <h2>{isRegister ? 'Cadastro de Profissional' : 'Login de Profissional'}</h2>
+      <form onSubmit={handleSubmit}>
+        {isRegister && (
+          <div>
+            <input
+              placeholder="Nome"
+              value={name}
+              onChange={e => setName(e.target.value)}
+            />
+          </div>
+        )}
+        <div>
+          <input
+            placeholder="Telefone"
+            value={phone}
+            onChange={e => setPhone(e.target.value)}
+          />
+        </div>
+        <div>
+          <input
+            type="password"
+            placeholder="Senha"
+            value={password}
+            onChange={e => setPassword(e.target.value)}
+          />
+        </div>
+        <button type="submit" style={{ background: 'var(--secondary-color)', color: '#fff', border: 0, padding: '0.5rem', marginTop: '0.5rem' }}>Enviar</button>
+      </form>
+      <button onClick={() => setIsRegister(!isRegister)} style={{ marginTop: '1rem', background: 'var(--secondary-color)', color: '#fff', border: 0, padding: '0.5rem' }}>
+        {isRegister ? 'Já tenho conta' : 'Quero me cadastrar'}
+      </button>
+      <div>{message}</div>
+    </div>
+  );
+}
+
+export default BarberAuthPage;

--- a/src/pages/BarberDashboard.jsx
+++ b/src/pages/BarberDashboard.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+function BarberDashboard() {
+  return (
+    <div style={{ padding: '1rem', color: '#171717' }}>
+      <h2>Painel do Barbeiro</h2>
+      <ol>
+        <li>Gerenciar serviços oferecidos</li>
+        <li>Definir disponibilidade de horários</li>
+        <li>Acompanhar agendamentos</li>
+      </ol>
+    </div>
+  );
+}
+
+export default BarberDashboard;


### PR DESCRIPTION
## Summary
- implement PHP endpoints for barber registration and login
- route new endpoints in backend router and update backend docs
- add React pages for barber login/registration and dashboard
- add `ProtectedRoute` component and wire up routes

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869bc2c034083309cf1cbcae15d7615