### PR TITLE
Improve register page styling

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,11 +1,19 @@
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap');
+
 * {
   margin: 0;
   padding: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+  box-sizing: border-box;
+  font-family: 'Poppins', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto',
+    'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+body {
+  margin: 0;
+  background-color: #171717;
 }
 
 code {

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,9 @@
 // src/index.js
 
 import React from 'react';
-import { createRoot } from 'react-dom/client';      
+import { createRoot } from 'react-dom/client';
 import App from './App.js';
+import './index.css';
 
 const container = document.getElementById('root');
 const root = createRoot(container);                

--- a/src/public/screens/register.jsx
+++ b/src/public/screens/register.jsx
@@ -38,7 +38,7 @@ export default function Register() {
   return (
     <div style={styles.container}>
       <div style={styles.card}>
-        <h1 style={styles.title}>AGENDA</h1>
+        <h1 style={styles.title}>REGISTRE-SE</h1>
         <form onSubmit={handleSubmit} style={styles.form}>
           <FloatingInput
             label="Nome"

--- a/src/public/screens/register.jsx
+++ b/src/public/screens/register.jsx
@@ -37,14 +37,15 @@ export default function Register() {
 
   return (
     <div style={styles.container}>
-      <h1 style={styles.title}>AGENDA</h1>
-      <form onSubmit={handleSubmit} style={styles.form}>
-        <FloatingInput
-          label="Nome"
-          name="nome"
-          value={form.nome}
-          onChange={handleChange}
-        />
+      <div style={styles.card}>
+        <h1 style={styles.title}>AGENDA</h1>
+        <form onSubmit={handleSubmit} style={styles.form}>
+          <FloatingInput
+            label="Nome"
+            name="nome"
+            value={form.nome}
+            onChange={handleChange}
+          />
         <FloatingInput
           label="Telefone"
           name="telefone"
@@ -69,16 +70,17 @@ export default function Register() {
 
         {erro && <span style={styles.error}>{erro}</span>}
 
-        <button type="submit" style={styles.button}>
-          CADASTRAR
-        </button>
-      </form>
-      <p style={styles.footerLink}>
-        Já tem uma conta?{' '}
-        <a href="/login" style={styles.linkAnchor}>
-          Entrar
-        </a>
-      </p>
+          <button type="submit" style={styles.button}>
+            CADASTRAR
+          </button>
+        </form>
+        <p style={styles.footerLink}>
+          Já tem uma conta?{' '}
+          <a href="/login" style={styles.linkAnchor}>
+            Entrar
+          </a>
+        </p>
+      </div>
     </div>
   );
 }
@@ -88,10 +90,20 @@ const styles = {
     backgroundColor: '#171717',
     minHeight: '100vh',
     display: 'flex',
-    flexDirection: 'column',
     alignItems: 'center',
     justifyContent: 'center',
-    padding: '0 16px',
+    padding: '16px',
+  },
+  card: {
+    width: '100%',
+    maxWidth: '400px',
+    backgroundColor: '#1f1f1f',
+    padding: '32px',
+    borderRadius: '8px',
+    boxShadow: '0 4px 12px rgba(0, 0, 0, 0.3)',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
   },
   title: {
     color: '#C38A42',
@@ -102,10 +114,9 @@ const styles = {
   },
   form: {
     width: '100%',
-    maxWidth: '360px',
     display: 'flex',
     flexDirection: 'column',
-    gap: '8px',
+    gap: '12px',
   },
   button: {
     marginTop: '16px',
@@ -117,6 +128,7 @@ const styles = {
     fontSize: '16px',
     fontWeight: 'bold',
     cursor: 'pointer',
+    transition: 'background-color 0.2s ease',
   },
   error: {
     color: '#FF5252',


### PR DESCRIPTION
## Summary
- apply Poppins font globally and remove default body margin
- import global styles in the React entrypoint
- restructure Register page with a centered card layout and smoother spacing

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a951e81808330846bef4c3a691b8d